### PR TITLE
Use selenium-grid-operator-sa ServiceAccount

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,3 +34,4 @@ spec:
               fieldRef:
                 fieldPath: metadata.annotations['olm.targetNamespaces']
       terminationGracePeriodSeconds: 10
+      serviceAccountName: sa

--- a/config/rbac/cluster_role_binding.yaml
+++ b/config/rbac/cluster_role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- service_account.yaml
 - cluster_role.yaml
 - cluster_role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/namespaced/kustomization.yaml
+++ b/config/rbac/namespaced/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- ../service_account.yaml
 - role.yaml
 - role_binding.yaml
 - ../leader_election_role.yaml

--- a/config/rbac/namespaced/role_binding.yaml
+++ b/config/rbac/namespaced/role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa


### PR DESCRIPTION
Prevents conflicts when multiple operators attempt to take ownership of the default Service Account.